### PR TITLE
make K8S operator more resilient against log-reading errors

### DIFF
--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -101,8 +101,13 @@ class PodLauncher(LoggingMixin):
 
         if get_logs:
             logs = self.read_pod_logs(pod)
-            for line in logs:
-                self.log.info(line)
+            try:
+                for line in logs:
+                    self.log.info(line)
+            except BaseHTTPError as e:
+                self.log.warning(
+                    'There was an error reading the kubernetes API for logs: {}'.format(e)
+                )
         result = None
         if self.extract_xcom:
             while self.base_container_is_running(pod):


### PR DESCRIPTION
in this case the k8s api returns a lazy iterator that will do IO after the read_pod_logs method. That K8S IO fails and this a is a patch to make it resilient.

